### PR TITLE
Fix report generation failure on UTF8 encoding.

### DIFF
--- a/app/views/admin/reports.html.erb
+++ b/app/views/admin/reports.html.erb
@@ -117,7 +117,7 @@
             handle = window.open();
         }
         $.get(url, function(data){
-            var csv = 'data:attachment/csv;base64,' + btoa(data.csv);
+            var csv = 'data:attachment/csv;base64,' + btoa(unescape(encodeURIComponent(data.csv)));
             if(typeof anchor.download === 'string'){
                 anchor.download = fileName;
                 anchor.href = csv;


### PR DESCRIPTION
Tested manually. Fix found here: https://stackoverflow.com/questions/23223718/failed-to-execute-btoa-on-window-the-string-to-be-encoded-contains-characte